### PR TITLE
Adding other routes and better load generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ npm install
 - `./start-demo`
 - Sign in and validate your StrongLoop license
 - Toggle the on/off switch to start tracing
-- `./send-requests-repeatedly`
+- `node send-requests-repeatedly.js` (in a different terminal)
 - View the graph output in the StrongLoop Arc Tracing module
 
 ---
@@ -64,10 +64,10 @@ some graphs load, but the data won't fluctuate because the server we started
 earlier is not busy handling requests yet.
 
 Create some variation in the graphs by running the [`send-requests-repeatedly`
-script](send-requests-repeatedly) to make repeated cURL requests to the server:
+script](send-requests-repeatedly.js) to make repeated HTTP requests to the server:
 
 ```
-./send-requests-repeatedly
+node send-requests-repeatedly.js
 ```
 
 Look at the tracing data again and you should see some fluctuations this time

--- a/index.js
+++ b/index.js
@@ -1,23 +1,58 @@
-var express = require('express');
+var app = require('express')(),
+    http = require('http');
 
-var app = express();
+// ------- Our Leaky Class... ------- //
+
+var widgets = [];
+function Widget() {}
+
+// ------- Our Routes ------- //
 
 app.get('/', function(req, res) {
-  res.send('Tracing Demo App is running');
+    res.json({ msg: 'Tracing Demo App running', widgetCount: widgets.length });
 });
 
-app.get('/spike', function(req, res) {
-  function LeakyClass() {}
-
-  var leaks = [];
-  for (var i = 0; i < 1000; i++)
-    leaks.push(new LeakyClass());
-  leaks = [];
-  console.log(leaks.length);
-  res.end('.');
+app.post('/widget', function(req, res) {
+    var count = (req.query.count || 10);
+    
+    for (var i = 0; i < count; i++) {
+        widgets.push(new Widget());
+    }
+    
+    res.json({ widgetCount: widgets.length });
 });
+
+app.get('/google', function(req, res) {
+    var options = {
+        path: 'https://google.com',
+        method: 'GET',
+        headers: { 'Content-Length': 0 }
+    };
+    
+    var googleReq = http.request(options, function(googleRes) {
+        var err = null,
+            body = '';
+        
+        googleRes.on('end', function () {
+            res.json({ msg: 'I hit google!' });
+        });
+    });
+    googleReq.on('error', function(err) {
+        res.json({ msg: err.message });
+    });
+    googleReq.end();
+});
+
+app.get('/clear', function(req, res) {
+    widgets = widgets.slice(Math.round(widgets.length / 2));
+    res.json({ msg: 'Cleared all widgets', widgetCount: widgets.length });
+});
+
+
+// ------- Start it up ------- //
 
 var port = process.env.PORT || 3001;
+
 app.listen(port, function() {
-  console.log('Listening on', port);
+    console.log('Tracing demo app listening on', port);
 });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "homepage": "https://github.com/strongloop/tracing-example-app",
   "dependencies": {
-    "express": "^4.12.4",
-    "request": "^2.58.0"
+    "express": "^4.12.4"
   }
 }

--- a/send-requests-repeatedly
+++ b/send-requests-repeatedly
@@ -1,4 +1,0 @@
-while true; do
-  curl localhost:3001/spike
-  sleep ${1-10}
-done

--- a/send-requests-repeatedly.js
+++ b/send-requests-repeatedly.js
@@ -1,0 +1,187 @@
+/**
+ * This script helps to artifically generate load on a web application through
+ * weighted requests to various endpoints. It may not be pretty, but it works 
+ * for me. :) Feel free to use however you want.
+ * 
+ * NOTE: Please use responsibly, don't run this script against a production server!
+ * 
+ * @author Jordan Kasper (@jakerella)
+ * @license MIT
+ */
+
+var http = require('http');
+
+var config = {
+    // Options passed directly into the http.request(...) method on each request
+    httpOptions: {
+        host: 'localhost',
+        port: 3001,
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    },
+    // Use the array below to specify requests to send to the application
+    // Note that the "weights" should add up to 1.0, but will be approximated
+    requests: [
+        { path: '/widget?count=10000', method: 'POST', weight: 0.44 },
+        { path: '/google', method: 'GET', weight: 0.45 },
+        { path: '/clear', method: 'GET', weight: 0.01, ignoreSpikes: true }
+    ],
+    responseEncoding: 'utf8',
+    stopOnReqError: false, // If true, stops the Node process on request errors (NOT http status codes)
+    logHTTPErrors: false,  // Logs any 400+ status code... can be chatty
+    stopOn400: false,      // Forces an exit on the Node process on 4XX errors
+    stopOn500: false,      // Forces an exit on the Node process on 5XX errors
+    requestsPerSecond: 5,
+    trafficSpikeFreq: [60000, 120000],
+    trafficSpikeAmplitude: [200, 300],
+    
+    // The items below are used internally and may be overridden, don't use them!
+    maxWeight: 100,
+    weighted: [],
+    waitTime: 1000
+};
+
+(function setup() {
+    var spikeTimeout = getSpikeTimeout(),
+        maxWeight = (config.requests.length > 10 && 100) || config.maxWeight || 10;
+    
+    config.requests.forEach(function(request, reqIndex) {
+        for (var i=0; i < (request.weight || 0.1) * maxWeight; ++i) {
+            config.weighted.push(reqIndex);
+        }
+    });
+    
+    config.waitTime = 1000 / config.requestsPerSecond
+    
+    console.log('Beginning load generation at 1 req per ' + config.waitTime + 'ms.');
+    console.log('Using weighted requests:\n' + config.weighted);
+    console.log('Press "Ctrl + C" to stop.\n');
+    
+    sendNext();
+    
+    if (spikeTimeout) {
+        setTimeout(sendSpike, spikeTimeout);
+    }
+})();
+
+
+function sendNext() {
+    var nextIndex = config.weighted[ Math.floor(Math.random() * config.weighted.length) ],
+        request = config.requests[ nextIndex ];
+    
+    sendRequest(request.method, request.path, request.data, function(err, res) {
+        if (err) {
+            console.error(err);
+        }
+    });
+    
+    setTimeout(sendNext, config.waitTime);
+}
+
+
+function sendSpike() {
+    var i, nextIndex, request,
+        numRequests = 0,
+        nextSpike = getSpikeTimeout();
+    
+    if (typeof config.trafficSpikeAmplitude === 'number') {
+        
+        numRequests = config.trafficSpikeAmplitude;
+        
+    } else {
+        
+        numRequests = Math.floor(
+            (Math.random() * (config.trafficSpikeAmplitude[1] - config.trafficSpikeAmplitude[0])) +
+            config.trafficSpikeAmplitude[0]
+        );
+        
+    }
+    
+    console.log('Sending traffic spike with ' + numRequests + ' requests...');
+    
+    for (i=0; i<numRequests; ++i) {
+        nextIndex = config.weighted[ Math.floor(Math.random() * config.weighted.length) ];
+        request = config.requests[ nextIndex ];
+        
+        if (request.ignoreSpikes) {
+            i--;
+            continue;
+        }
+        
+        sendRequest(request.method, request.path, request.data);
+    }
+    
+    if (nextSpike) {
+        setTimeout(sendSpike, nextSpike);
+    }
+}
+
+
+function sendRequest(method, path, data, cb) {
+    var options = config.httpOptions || {};
+    options.path = path || '/';
+    options.method = method || 'GET';
+    options.headers = options.headers || {};
+    options.headers['Content-Length'] = (data && data.length) || 0;
+    
+    var req = http.request(options, function(res) {
+        var err = null,
+            body = '';
+        
+        res.setEncoding(config.responseEncoding);
+        res.on('data', function (chunk) {
+            body += chunk;
+        });
+        res.on('end', function () {
+            res.body = body;
+            
+            if (res.statusCode > 399) {
+                err = new Error(body);
+                err.status = err.code = res.statusCode;
+                
+                if (config.logHTTPErrors) {
+                    console.error('Server returned error from ', options.method + ' ' + options.path, res.statusCode);
+                }
+                
+                if (res.statusCode > 499 && config.stopOn500) {
+                    process.exit(1);
+                } else if (res.statusCode > 399 && config.stopOn400) {
+                    process.exit(1);
+                }
+            }
+            
+            cb && cb(err, res);
+        });
+    });
+    
+    req.on('error', function(err) {
+        console.error('Error with request:', err.message);
+        if (config.stopOnReqError) {
+            process.exit(1);
+        } else {
+            cb && cb(err);
+        }
+    });
+    
+    if (data) {
+        req.write(data);
+    }
+    req.end();
+}
+
+function getSpikeTimeout() {
+    if (typeof config.trafficSpikeFreq === 'number') {
+        
+        return config.trafficSpikeFreq;
+        
+    } else if (config.trafficSpikeFreq && config.trafficSpikeFreq.splice && config.trafficSpikeFreq.length === 2) {
+    
+        return Math.floor(
+            (Math.random() * (config.trafficSpikeFreq[1] - config.trafficSpikeFreq[0])) +
+            config.trafficSpikeFreq[0]
+        );
+    } else {
+        return null;
+    }
+}

--- a/start-demo
+++ b/start-demo
@@ -1,3 +1,3 @@
 slc start
-slc ctl set-size 1 1
+slc ctl set-size tracing-example-app 1
 slc arc

--- a/start-demo
+++ b/start-demo
@@ -1,3 +1,27 @@
+echo "--------------------------"
+echo "`date` -- Restarting tracing example app"
+
+echo "*** Shutting down any running PM (and load generation)..."
+pkill -ecf repeatedly
+pkill -ecf "slc arc"
+slc ctl stop tracing-example-app
+
+echo "*** (Re)Starting PM..."
+sleep 2s
 slc start
+
+echo "*** Setting cluster size to 1..."
 slc ctl set-size tracing-example-app 1
-slc arc
+
+echo "*** Starting Arc on port 4000..."
+PORT=4000 nohup slc arc 1>../logs/tracing.log 2>../logs/tracing-err.log &
+
+echo "*** Turning on transaction tracing"
+slc ctl tracing-stop tracing-example-app
+slc ctl tracing-start tracing-example-app
+
+echo "*** Starting load generation (after 5s)..."
+sleep 3s
+node send-requests-repeatedly.js 1>/dev/null 2>1 &
+
+echo "*** ALL DONE! ***"

--- a/stop-demo
+++ b/stop-demo
@@ -1,6 +1,0 @@
-rm -rf ~/.strong-pm
-rm ./pmctl
-rm ./runctl
-rm ./arc-manager.json
-rm -rf .strong-pm
-slc ctl shutdown


### PR DESCRIPTION
This updated version includes other routes to show sync vs async routes and to potentially show anomolies in the memory usage by retaining objects in memory beyond request-response cycle.

In order to facilitate better charts, I removed the old send-requests-repeatedly script and use a Node-based HTTP request generator with weighted request configs.

I also resolved #2 (although it won't matter too much, read those comments) and removed an unused dependency.
